### PR TITLE
libobjc2: Prevent using default GNUstep installation directory

### DIFF
--- a/ports/libobjc2/portfile.cmake
+++ b/ports/libobjc2/portfile.cmake
@@ -10,6 +10,8 @@ vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         ${OPTIONS}
+        # Prevent picking up a default install location through gnustep-config
+        -DGNUSTEP_INSTALL_TYPE=NONE
 )
 
 vcpkg_cmake_install()


### PR DESCRIPTION
Set `-DGNUSTEP_INSTALL_TYPE=NONE` to prevent libobjc2 from picking up a default install location through gnustep-config