### PR TITLE
Move VCPKG_CMAKE_SYSTEM_NAME to triplet flie

### DIFF
--- a/triplets/toolchains/x64-linux-llvm.toolchain.cmake
+++ b/triplets/toolchains/x64-linux-llvm.toolchain.cmake
@@ -1,4 +1,2 @@
-set(VCPKG_CMAKE_SYSTEM_NAME Linux)
-
 set(CMAKE_C_COMPILER clang CACHE INTERNAL "C compiler")
 set(CMAKE_CXX_COMPILER clang++ CACHE INTERNAL "C++ compiler")

--- a/triplets/x64-linux-llvm.cmake
+++ b/triplets/x64-linux-llvm.cmake
@@ -2,6 +2,8 @@ set(VCPKG_TARGET_ARCHITECTURE x64)
 set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE dynamic)
 
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
 # Configure toolchain
 set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/toolchains/x64-linux-llvm.toolchain.cmake")
 


### PR DESCRIPTION
This is a vcpkg-specific variable (used by vcpkg to determine the triplet); shouldn't be in the toolchain.