### PR TITLE
Add vcpkg-gnustep, gnustep-make

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,16 +51,18 @@ jobs:
       - name: Install dependencies (Ubuntu)
         run: |
           apt-get update
-          apt-get install -y clang curl zip unzip tar git pkg-config
+          apt-get install -y clang curl zip unzip tar git pkg-config make
         if: matrix.family == 'ubuntu'
       - name: Install dependencies (Enterprise Linux)
         run: |
-          yum install -y clang zip unzip tar git pkg-config
+          yum install -y clang zip unzip tar git pkg-config which
         if: matrix.family == 'rhel'
       - name: Bootstrap vcpkg
         run: ./bootstrap-vcpkg.sh
       - name: Install libobjc2
         run: ./vcpkg install libobjc2:x64-linux-llvm
+      - name: Install gnustep-make
+        run: ./vcpkg install gnustep-make:x64-linux-llvm
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/ports/gnustep-make/portfile.cmake
+++ b/ports/gnustep-make/portfile.cmake
@@ -1,0 +1,66 @@
+string(REPLACE "." "_" MAKE_VERSION ${VERSION})
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO gnustep/tools-make
+    REF "make-${MAKE_VERSION}"
+    SHA512 ec1a21a36cd39d354dc1ed88e2c0b576ae5418af562f6ecb66619442d967a22b0eb7dee9914cfe4430674ca0c409d5755df76308a7c90af64ab9dbeaf9b85b28
+    HEAD_REF master
+    PATCHES
+)
+
+vcpkg_configure_gnustep(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        --with-library-combo=ng-gnu-gnu
+        --with-runtime-abi=gnustep-2.2
+)
+
+vcpkg_install_gnustep()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# Empty directories
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/GNUstep/Makefiles/Additional")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/GNUstep/Makefiles/Auxiliary")
+
+# Utilities which are not used in the build process and contain absolute path
+file(REMOVE "${CURRENT_PACKAGES_DIR}/bin/debugapp")
+file(REMOVE "${CURRENT_PACKAGES_DIR}/bin/gnustep-tests")
+file(REMOVE "${CURRENT_PACKAGES_DIR}/bin/openapp")
+file(REMOVE "${CURRENT_PACKAGES_DIR}/bin/opentool")
+
+file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/debugapp")
+file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/gnustep-tests")
+file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/openapp")
+file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/opentool")
+
+# These files contain absolute paths and are not portable
+file(REMOVE "${CURRENT_PACKAGES_DIR}/etc/GNUstep/GNUstep.conf")
+file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/etc/GNUstep/GNUstep.conf")
+
+# Fix path in gnustep-config, GNUstep.sh, GNUstep.conf and filesystem.sh
+function(z_vcpkg_fixup_gnustep_path file find replace)
+    file(READ ${file} contents)
+    string(REPLACE ${find} ${replace} contents "${contents}")
+    file(WRITE ${file} "${contents}")
+endfunction()
+
+z_vcpkg_fixup_gnustep_path("${CURRENT_PACKAGES_DIR}/bin/gnustep-config" "${CURRENT_INSTALLED_DIR}" "$(realpath \"$(dirname $0)/../\")")
+
+if (NOT VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    # ./debug/share does not exist, so redirect to ./share; but fixup the other paths relative to ./debug
+    z_vcpkg_fixup_gnustep_path("${CURRENT_PACKAGES_DIR}/debug/bin/gnustep-config" "${CURRENT_INSTALLED_DIR}/debug/share" "$(realpath \"$(dirname $0)/../../share/\")")
+    z_vcpkg_fixup_gnustep_path("${CURRENT_PACKAGES_DIR}/debug/bin/gnustep-config" "${CURRENT_INSTALLED_DIR}" "$(realpath \"$(dirname $0)/../\")")
+endif()
+
+# because GNUstep.sh is sourced, use ${BASH_SOURCE[0]}.  This is less portable but works.
+z_vcpkg_fixup_gnustep_path("${CURRENT_PACKAGES_DIR}/share/GNUstep/Makefiles/GNUstep.sh" "${CURRENT_INSTALLED_DIR}" "$(realpath \"$(dirname \${BASH_SOURCE[0]})/../../../\")")
+z_vcpkg_fixup_gnustep_path("${CURRENT_PACKAGES_DIR}/share/GNUstep/Makefiles/GNUstep-reset.sh" "${CURRENT_INSTALLED_DIR}" "$(realpath \"$(dirname \${BASH_SOURCE[0]})/../../../\")")
+z_vcpkg_fixup_gnustep_path("${CURRENT_PACKAGES_DIR}/share/GNUstep/Makefiles/filesystem.sh" "${CURRENT_INSTALLED_DIR}" "$(realpath \"$(dirname \${BASH_SOURCE[0]})/../../../\")")
+
+# gnustep-make has no headers
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+
+set(VCPKG_POLICY_ALLOW_EMPTY_FOLDERS enabled)

--- a/ports/gnustep-make/vcpkg.json
+++ b/ports/gnustep-make/vcpkg.json
@@ -1,0 +1,17 @@
+{
+    "name": "gnustep-make",
+    "version": "2.9.2",
+    "description": "The makefile package is a simple, powerful and extensible way to write makefiles for a GNUstep-based project.",
+    "homepage": "https://github.com/gnustep/tools-make",
+    "license": "GPL-3.0",
+    "supports": "!static & linux",
+    "dependencies": [
+      {
+        "name": "libobjc2"
+      },
+      {
+        "name": "vcpkg-gnustep",
+        "host": true
+      }
+    ]
+}

--- a/ports/vcpkg-gnustep/copyright
+++ b/ports/vcpkg-gnustep/copyright
@@ -1,0 +1,23 @@
+Copyright (c) Keysight Technologies
+
+All rights reserved. 
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ports/vcpkg-gnustep/portfile.cmake
+++ b/ports/vcpkg-gnustep/portfile.cmake
@@ -1,0 +1,14 @@
+if(VCPKG_CROSSCOMPILING)
+    # make FATAL_ERROR in CI when issue #16773 fixed
+    message(WARNING "vcpkg-gnustep is a host-only port; please mark it as a host port in your dependencies.")
+endif()
+
+file(INSTALL
+    "${CMAKE_CURRENT_LIST_DIR}/vcpkg_configure_gnustep.cmake"
+    "${CMAKE_CURRENT_LIST_DIR}/vcpkg_install_gnustep.cmake"
+    "${CMAKE_CURRENT_LIST_DIR}/vcpkg-port-config.cmake"
+    "${CMAKE_CURRENT_LIST_DIR}/copyright"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+set(VCPKG_POLICY_CMAKE_HELPER_PORT enabled)
+

--- a/ports/vcpkg-gnustep/vcpkg-port-config.cmake
+++ b/ports/vcpkg-gnustep/vcpkg-port-config.cmake
@@ -1,0 +1,2 @@
+include("${CMAKE_CURRENT_LIST_DIR}/vcpkg_configure_gnustep.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/vcpkg_install_gnustep.cmake")

--- a/ports/vcpkg-gnustep/vcpkg.json
+++ b/ports/vcpkg-gnustep/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "vcpkg-gnustep",
+  "version": "0.0.1",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/ports/vcpkg-gnustep/vcpkg_configure_gnustep.cmake
+++ b/ports/vcpkg-gnustep/vcpkg_configure_gnustep.cmake
@@ -1,0 +1,27 @@
+include_guard(GLOBAL)
+
+set(Z_VCPKG_CMAKE_GET_VARS_CURRENT_LIST_DIR "${CMAKE_CURRENT_LIST_DIR}" CACHE INTERNAL "")
+
+function(vcpkg_configure_gnustep)
+    cmake_parse_arguments(PARSE_ARGV 0 "arg"
+        ""
+        "SOURCE_PATH"
+        "OPTIONS"
+    )
+
+    if (VCPKG_TARGET_IS_LINUX)
+        vcpkg_configure_make(
+            SOURCE_PATH ${arg_SOURCE_PATH}
+            # This would pass --disable-silent-rules, which is not supported by the GNUstep build system
+            DISABLE_VERBOSE_FLAGS
+            # Allow ./configure to find gnustep-config, which is in bin/
+            ADD_BIN_TO_PATH
+            # GNUstep does not support out-of-tree builds
+            COPY_SOURCE
+            OPTIONS
+                ${arg_OPTIONS}
+        )
+    else()
+        message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION} is not implemented for your platform")
+    endif()
+endfunction()

--- a/ports/vcpkg-gnustep/vcpkg_install_gnustep.cmake
+++ b/ports/vcpkg-gnustep/vcpkg_install_gnustep.cmake
@@ -1,0 +1,15 @@
+include_guard(GLOBAL)
+
+set(Z_VCPKG_CMAKE_GET_VARS_CURRENT_LIST_DIR "${CMAKE_CURRENT_LIST_DIR}" CACHE INTERNAL "")
+
+function(vcpkg_install_gnustep)
+    if (VCPKG_TARGET_IS_LINUX)
+        vcpkg_install_make(
+            MAKEFILE GNUmakefile
+            # Allow make to find gnustep-config, which is in bin/
+            ADD_BIN_TO_PATH
+        )
+    else()
+        message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION} is not implemented for your platform")
+    endif()
+endfunction()

--- a/triplets/x64-linux-llvm.cmake
+++ b/triplets/x64-linux-llvm.cmake
@@ -4,6 +4,10 @@ set(VCPKG_LIBRARY_LINKAGE dynamic)
 
 set(VCPKG_CMAKE_SYSTEM_NAME Linux)
 
+# GNUstep stores part of its build configuration in /share, which is shared across both the
+# release and debug builds in vcpkg.  This effectively breaks support for debug builds, for now.
+set(VCPKG_BUILD_TYPE release)
+
 # Configure toolchain
 set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/toolchains/x64-linux-llvm.toolchain.cmake")
 


### PR DESCRIPTION
This commit add basic support for building GNUstep using vcpkg on Linux.

- It introduces a vcpkg-gnustep helper port, which exposes a `vcpkg_configure_gnustep` and `vcpgk_install_gnustep` function, which contains common code required to run `./configure` and `make install` for GNUstep
- Adds the `gnustep-make` package, which installs tools-make in vcpkg.  It includes additional logic to ensure relative paths are used where possible.