### PR TITLE
Use Windows 2019 runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   windows:
-    runs-on: windows-2022
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@v4
       - name: Bootstrap vcpkg


### PR DESCRIPTION
There are reports that this runner may offer better performance