### PR TITLE
Don't set Z_VCPKG_CMAKE_GET_VARS_CURRENT_LIST_DIR

### DIFF
--- a/ports/vcpkg-gnustep/vcpkg_configure_gnustep.cmake
+++ b/ports/vcpkg-gnustep/vcpkg_configure_gnustep.cmake
@@ -1,7 +1,5 @@
 include_guard(GLOBAL)
 
-set(Z_VCPKG_CMAKE_GET_VARS_CURRENT_LIST_DIR "${CMAKE_CURRENT_LIST_DIR}" CACHE INTERNAL "")
-
 function(vcpkg_configure_gnustep)
     cmake_parse_arguments(PARSE_ARGV 0 "arg"
         ""

--- a/ports/vcpkg-gnustep/vcpkg_install_gnustep.cmake
+++ b/ports/vcpkg-gnustep/vcpkg_install_gnustep.cmake
@@ -1,7 +1,5 @@
 include_guard(GLOBAL)
 
-set(Z_VCPKG_CMAKE_GET_VARS_CURRENT_LIST_DIR "${CMAKE_CURRENT_LIST_DIR}" CACHE INTERNAL "")
-
 function(vcpkg_install_gnustep)
     if (VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_WINDOWS)
         vcpkg_install_make(


### PR DESCRIPTION
This should be set by `vcpkg-cmake-get-vars
/vcpkg_cmake_get_vars.cmake`; it is included as part of a copy/paste error