### PR TITLE
Support minimal build of gnustep-base on Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
       - name: Bootstrap vcpkg

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,8 @@ jobs:
         run: ./vcpkg install libobjc2:x64-windows-llvm
       - name: Install gnustep-make
         run: ./vcpkg install gnustep-make:x64-windows-llvm
+      - name: Install gnustep-base
+        run: ./vcpkg install gnustep-base:x64-windows-llvm
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/ports/gnustep-base/portfile.cmake
+++ b/ports/gnustep-base/portfile.cmake
@@ -9,6 +9,16 @@ vcpkg_from_github(
     PATCHES
 )
 
+vcpkg_list(SET options)
+
+if (VCPKG_TARGET_IS_WINDOWS)
+    # Disable a bunch of options for now; this allows us to get a minimal libs-base port merged into main;
+    # and we can then light up extra features one by one.
+    vcpkg_list(APPEND options "--disable-iconv")
+    vcpkg_list(APPEND options "--disable-xml")
+    vcpkg_list(APPEND options "--disable-tls")
+endif ()
+
 vcpkg_configure_gnustep(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
@@ -16,9 +26,14 @@ vcpkg_configure_gnustep(
         --disable-importing-config-file
         # gnustep-config is not in PATH, so specify the path to the makefiles
         GNUSTEP_MAKEFILES=${CURRENT_INSTALLED_DIR}/share/GNUstep/Makefiles/
+        ${options}
 )
 
-vcpkg_install_gnustep()
+vcpkg_install_gnustep(
+    OPTIONS
+        # gnustep-config is not in PATH, so specify the path to the makefiles
+        GNUSTEP_MAKEFILES=${CURRENT_INSTALLED_DIR}/share/GNUstep/Makefiles/
+)
 
 vcpkg_fixup_pkgconfig()
 

--- a/ports/gnustep-base/portfile.cmake
+++ b/ports/gnustep-base/portfile.cmake
@@ -33,6 +33,7 @@ vcpkg_install_gnustep(
     OPTIONS
         # gnustep-config is not in PATH, so specify the path to the makefiles
         GNUSTEP_MAKEFILES=${CURRENT_INSTALLED_DIR}/share/GNUstep/Makefiles/
+        GNUSTEP_INSTALLATION_DOMAIN=LOCAL
 )
 
 vcpkg_fixup_pkgconfig()

--- a/ports/gnustep-base/vcpkg.json
+++ b/ports/gnustep-base/vcpkg.json
@@ -4,13 +4,17 @@
     "description": "The GNUstep Base Library is a library of general-purpose, non-graphical Objective C objects.",
     "homepage": "https://github.com/gnustep/libs-base",
     "license": "LGPL-2.1",
-    "supports": "!static & linux",
+    "supports": "!static & (linux | windows)",
     "dependencies": [
       {
         "name": "libobjc2"
       },
       {
         "name": "gnustep-make"
+      },
+      {
+        "name": "libffi",
+        "platform": "windows"
       },
       {
         "name": "vcpkg-gnustep",

--- a/ports/libffi/dll-bindir.diff
+++ b/ports/libffi/dll-bindir.diff
@@ -1,0 +1,12 @@
+diff --git a/configure.host b/configure.host
+index f23716f..78d317b 100644
+--- a/configure.host
++++ b/configure.host
+@@ -103,6 +103,7 @@ case "${host}" in
+ 	else
+ 	  AM_LTLDFLAGS='-no-undefined -bindir "$(bindir)"';
+ 	fi
++	AM_LTLDFLAGS='-no-undefined';
+ 	;;
+ 
+   i?86-*-darwin* | x86_64-*-darwin* | i?86-*-ios | x86_64-*-ios)

--- a/ports/libffi/libffiConfig.cmake
+++ b/ports/libffi/libffiConfig.cmake
@@ -1,0 +1,7 @@
+file(READ "${CMAKE_CURRENT_LIST_DIR}/usage" usage)
+message(WARNING "find_package(libffi) is deprecated.\n${usage}")
+include(CMakeFindDependencyMacro)
+find_dependency(unofficial-libffi CONFIG REQUIRED)
+if(NOT TARGET libffi)
+    add_library(libffi ALIAS unofficial::libffi::libffi)
+endif()

--- a/ports/libffi/portfile.cmake
+++ b/ports/libffi/portfile.cmake
@@ -1,0 +1,77 @@
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/libffi/libffi/releases/download/v${VERSION}/libffi-${VERSION}.tar.gz"
+    FILENAME "libffi-${VERSION}.tar.gz"
+    SHA512 033d2600e879b83c6bce0eb80f69c5f32aa775bf2e962c9d39fbd21226fa19d1e79173d8eaa0d0157014d54509ea73315ad86842356fc3a303c0831c94c6ab39
+)
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    PATCHES
+        dll-bindir.diff
+)
+
+vcpkg_list(SET options)
+if(VCPKG_TARGET_IS_WINDOWS)
+    set(linkage_flag "-DFFI_STATIC_BUILD")
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+        set(linkage_flag "-DFFI_BUILDING_DLL")
+    endif()
+    vcpkg_list(APPEND options "CFLAGS=\${CFLAGS} ${linkage_flag}")
+endif()
+
+set(ccas_options "")
+vcpkg_cmake_get_vars(cmake_vars_file)
+include("${cmake_vars_file}")
+if(VCPKG_DETECTED_CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+    set(ccas "${SOURCE_PATH}/msvcc.sh")
+    if(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+        string(APPEND ccas_options " -m32")
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x64")
+        string(APPEND ccas_options " -m64")
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
+        string(APPEND ccas_options " -marm")
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+        string(APPEND ccas_options " -marm64")
+    endif()
+else()
+    set(ccas "${VCPKG_DETECTED_CMAKE_C_COMPILER}")
+endif()
+cmake_path(GET ccas PARENT_PATH ccas_dir)
+vcpkg_add_to_path("${ccas_dir}")
+cmake_path(GET ccas FILENAME ccas_command)
+vcpkg_list(APPEND options "CCAS=${ccas_command}${ccas_options}")
+
+set(configure_triplets DETERMINE_BUILD_TRIPLET)
+if(VCPKG_TARGET_IS_EMSCRIPTEN)
+    set(configure_triplets BUILD_TRIPLET "--host=wasm32-unknown-emscripten --build=\$(\$SHELL \"${SOURCE_PATH}/config.guess\")")
+endif()
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    ${configure_triplets}
+    USE_WRAPPERS
+    OPTIONS
+        --enable-portable-binary
+        --disable-docs
+        --disable-multi-os-directory
+        ${options}
+)
+
+vcpkg_install_make()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/ffi.h" "defined(FFI_STATIC_BUILD)" "1")
+endif()
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/unofficial-libffi-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/unofficial-libffi")
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/libffiConfig.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/share/man3"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/libffi/portfile.cmake
+++ b/ports/libffi/portfile.cmake
@@ -13,10 +13,7 @@ vcpkg_extract_source_archive(
 vcpkg_list(SET options)
 if(VCPKG_TARGET_IS_WINDOWS)
     set(linkage_flag "-DFFI_STATIC_BUILD")
-    if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
-        set(linkage_flag "-DFFI_BUILDING_DLL")
-    endif()
-    vcpkg_list(APPEND options "CFLAGS=\${CFLAGS} ${linkage_flag}")
+    vcpkg_list(APPEND options "CFLAGS=\"\${CFLAGS} ${linkage_flag}\"")
 endif()
 
 set(ccas_options "")
@@ -46,7 +43,7 @@ if(VCPKG_TARGET_IS_EMSCRIPTEN)
     set(configure_triplets BUILD_TRIPLET "--host=wasm32-unknown-emscripten --build=\$(\$SHELL \"${SOURCE_PATH}/config.guess\")")
 endif()
 
-vcpkg_configure_make(
+vcpkg_configure_gnustep(
     SOURCE_PATH "${SOURCE_PATH}"
     ${configure_triplets}
     USE_WRAPPERS
@@ -61,15 +58,14 @@ vcpkg_install_make()
 vcpkg_copy_pdbs()
 vcpkg_fixup_pkgconfig()
 
-if (VCPKG_LIBRARY_LINKAGE STREQUAL "static")
-    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/ffi.h" "defined(FFI_STATIC_BUILD)" "1")
-endif()
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/ffi.h" "defined(FFI_STATIC_BUILD)" "1")
 
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/unofficial-libffi-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/unofficial-libffi")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/libffiConfig.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"
     "${CURRENT_PACKAGES_DIR}/share/man3"
 )

--- a/ports/libffi/portfile.cmake
+++ b/ports/libffi/portfile.cmake
@@ -64,6 +64,10 @@ file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_D
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/unofficial-libffi-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/unofficial-libffi")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/libffiConfig.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
+# Rename libffi.a to ffi.lib:
+file(RENAME "${CURRENT_PACKAGES_DIR}/lib/libffi.a" "${CURRENT_PACKAGES_DIR}/lib/ffi.lib")
+file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/libffi.a" "${CURRENT_PACKAGES_DIR}/debug/lib/ffi.lib")
+
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"

--- a/ports/libffi/unofficial-libffi-config.cmake
+++ b/ports/libffi/unofficial-libffi-config.cmake
@@ -1,0 +1,20 @@
+if(NOT TARGET unofficial::libffi::libffi)
+    get_filename_component(VCPKG_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_DIR}/../../" ABSOLUTE)
+    find_library(VCPKG_LIBFFI_LIBRARY_RELEASE NAMES ffi PATHS "${VCPKG_IMPORT_PREFIX}/lib" REQUIRED)
+    find_library(VCPKG_LIBFFI_LIBRARY_DEBUG NAMES ffi PATHS "${VCPKG_IMPORT_PREFIX}/debug/lib")
+    mark_as_advanced(VCPKG_LIBFFI_LIBRARY_RELEASE VCPKG_LIBFFI_LIBRARY_DEBUG)
+    add_library(unofficial::libffi::libffi UNKNOWN IMPORTED)
+    set_target_properties(unofficial::libffi::libffi PROPERTIES
+        IMPORTED_CONFIGURATIONS "Release"
+        INTERFACE_INCLUDE_DIRECTORIES "${VCPKG_IMPORT_PREFIX}/include"
+        IMPORTED_LOCATION_RELEASE "${VCPKG_LIBFFI_LIBRARY_RELEASE}"
+        IMPORTED_LINK_INTERFACE_LANGUAGES_RELEASE "C"
+    )
+    if(VCPKG_LIBFFI_LIBRARY_DEBUG)
+        set_property(TARGET unofficial::libffi::libffi APPEND PROPERTY IMPORTED_CONFIGURATIONS Debug)
+        set_target_properties(unofficial::libffi::libffi PROPERTIES
+            IMPORTED_LOCATION_DEBUG "${VCPKG_LIBFFI_LIBRARY_DEBUG}"
+            IMPORTED_LINK_INTERFACE_LANGUAGES_DEBUG "C"
+        )
+    endif()
+endif()

--- a/ports/libffi/usage
+++ b/ports/libffi/usage
@@ -1,0 +1,10 @@
+libffi can be imported via CMake FindPkgConfig module:
+
+    find_package(PkgConfig)
+    pkg_check_modules(LIBFFI REQUIRED IMPORTED_TARGET libffi)
+    target_link_libraries(main PRIVATE PkgConfig::LIBFFI)
+
+vcpkg provides proprietary CMake targets:
+
+    find_package(unofficial-libffi CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE unofficial::libffi::libffi)

--- a/ports/libffi/vcpkg.json
+++ b/ports/libffi/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "libffi",
+  "version": "3.4.6",
+  "description": "Portable, high level programming interface to various calling conventions",
+  "homepage": "https://github.com/libffi/libffi",
+  "license": "MIT",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake-get-vars",
+      "host": true
+    }
+  ]
+}

--- a/ports/libffi/vcpkg.json
+++ b/ports/libffi/vcpkg.json
@@ -8,6 +8,10 @@
     {
       "name": "vcpkg-cmake-get-vars",
       "host": true
+    },
+    {
+      "name": "vcpkg-gnustep",
+      "host": true
     }
   ]
 }

--- a/ports/vcpkg-gnustep/vcpkg_install_gnustep.cmake
+++ b/ports/vcpkg-gnustep/vcpkg_install_gnustep.cmake
@@ -7,8 +7,14 @@ function(vcpkg_install_gnustep)
         "OPTIONS"
     )
 
+    list(JOIN ${arg_OPTIONS} " " options_string)
+
     if (VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_WINDOWS)
-        vcpkg_install_make(
+        vcpkg_build_make(
+            ENABLE_INSTALL
+            # vcpkg_build_make passes OPTIONS to make [build] but not to make [install]; try to squeeze them in via
+            # the install target instead
+            INSTALL_TARGET install ${options_string}
             MAKEFILE GNUmakefile
             # Allow make to find gnustep-config, which is in bin/
             ADD_BIN_TO_PATH

--- a/ports/vcpkg-gnustep/vcpkg_install_gnustep.cmake
+++ b/ports/vcpkg-gnustep/vcpkg_install_gnustep.cmake
@@ -1,11 +1,19 @@
 include_guard(GLOBAL)
 
 function(vcpkg_install_gnustep)
+    cmake_parse_arguments(PARSE_ARGV 0 "arg"
+        ""
+        ""
+        "OPTIONS"
+    )
+
     if (VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_WINDOWS)
         vcpkg_install_make(
             MAKEFILE GNUmakefile
             # Allow make to find gnustep-config, which is in bin/
             ADD_BIN_TO_PATH
+            OPTIONS
+                ${arg_OPTIONS}
         )
     else()
         message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION} is not implemented for your platform")

--- a/triplets/x64-windows-llvm.cmake
+++ b/triplets/x64-windows-llvm.cmake
@@ -4,3 +4,4 @@ set(VCPKG_CRT_LINKAGE dynamic)
 
 # Configure toolchain
 set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/toolchains/x64-windows-llvm.toolchain.cmake")
+set(VCPKG_LOAD_VCVARS_ENV ON)


### PR DESCRIPTION
This adds a minimal gnustep-base configuration which builds on Windows.  Most of the dependencies are missing.