### PR TITLE
Support minimal build of gnustep-base on Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
       - name: Bootstrap vcpkg

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,8 @@ jobs:
         run: ./vcpkg install gnustep-make:x64-windows-llvm
       - name: Install libffi
         run: ./vcpkg install libffi:x64-windows-llvm
+      - name: Install gnustep-base
+        run: ./vcpkg install gnustep-base:x64-windows-llvm
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/ports/gnustep-base/portfile.cmake
+++ b/ports/gnustep-base/portfile.cmake
@@ -9,6 +9,16 @@ vcpkg_from_github(
     PATCHES
 )
 
+vcpkg_list(SET options)
+
+if (VCPKG_TARGET_IS_WINDOWS)
+    # Disable a bunch of options for now; this allows us to get a minimal libs-base port merged into main;
+    # and we can then light up extra features one by one.
+    vcpkg_list(APPEND options "--disable-iconv")
+    vcpkg_list(APPEND options "--disable-xml")
+    vcpkg_list(APPEND options "--disable-tls")
+endif ()
+
 vcpkg_configure_gnustep(
     SOURCE_PATH ${SOURCE_PATH}
     OPTIONS
@@ -16,9 +26,14 @@ vcpkg_configure_gnustep(
         --disable-importing-config-file
         # gnustep-config is not in PATH, so specify the path to the makefiles
         GNUSTEP_MAKEFILES=${CURRENT_INSTALLED_DIR}/share/GNUstep/Makefiles/
+        ${options}
 )
 
-vcpkg_install_gnustep()
+vcpkg_install_gnustep(
+    OPTIONS
+        # gnustep-config is not in PATH, so specify the path to the makefiles
+        GNUSTEP_MAKEFILES=${CURRENT_INSTALLED_DIR}/share/GNUstep/Makefiles/
+)
 
 vcpkg_fixup_pkgconfig()
 

--- a/ports/gnustep-base/vcpkg.json
+++ b/ports/gnustep-base/vcpkg.json
@@ -4,13 +4,17 @@
     "description": "The GNUstep Base Library is a library of general-purpose, non-graphical Objective C objects.",
     "homepage": "https://github.com/gnustep/libs-base",
     "license": "LGPL-2.1",
-    "supports": "!static & linux",
+    "supports": "!static & (linux | windows)",
     "dependencies": [
       {
         "name": "libobjc2"
       },
       {
         "name": "gnustep-make"
+      },
+      {
+        "name": "libffi",
+        "platform": "windows"
       },
       {
         "name": "vcpkg-gnustep",

--- a/ports/libffi/portfile.cmake
+++ b/ports/libffi/portfile.cmake
@@ -64,6 +64,10 @@ file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_D
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/unofficial-libffi-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/unofficial-libffi")
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/libffiConfig.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
+# Rename libffi.a to ffi.lib:
+file(RENAME "${CURRENT_PACKAGES_DIR}/lib/libffi.a" "${CURRENT_PACKAGES_DIR}/lib/ffi.lib")
+file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/libffi.a" "${CURRENT_PACKAGES_DIR}/debug/lib/ffi.lib")
+
 file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/include"
     "${CURRENT_PACKAGES_DIR}/debug/share"

--- a/ports/libffi/vcpkg.json
+++ b/ports/libffi/vcpkg.json
@@ -1,6 +1,7 @@
 {
   "name": "libffi",
   "version": "3.4.6",
+  "port-version": 1,
   "description": "Portable, high level programming interface to various calling conventions",
   "homepage": "https://github.com/libffi/libffi",
   "license": "MIT",

--- a/triplets/x64-windows-llvm.cmake
+++ b/triplets/x64-windows-llvm.cmake
@@ -4,3 +4,4 @@ set(VCPKG_CRT_LINKAGE dynamic)
 
 # Configure toolchain
 set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/toolchains/x64-windows-llvm.toolchain.cmake")
+set(VCPKG_LOAD_VCVARS_ENV ON)


### PR DESCRIPTION
This adds a minimal gnustep-base configuration which builds on Windows. Most of the dependencies are missing.