### PR TITLE
Search for clang in  C:\Program Files\LLVM\bin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,10 @@ jobs:
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
+      - name: Check LLVM version
+        # We need at least LLVM 18.0 for proper Objective C support.  Visual Studio 2022 ships with LLVM 17,
+        # so we need to make sure we pick up clang from C:\Program Files\LLVM\bin\
+        run: clang --version
       - name: Bootstrap vcpkg
         run: ./scripts/bootstrap.ps1
       - name: Install libobjc2

--- a/triplets/toolchains/x64-windows-llvm.toolchain.cmake
+++ b/triplets/toolchains/x64-windows-llvm.toolchain.cmake
@@ -1,23 +1,12 @@
-
-# Untracked since vcpkg will track the compiler version.
-set(VCPKG_ENV_PASSTHROUGH_UNTRACKED "LLVMInstallDir;LLVMToolsVersion") 
-
 # Get Program Files root to lookup possible LLVM installation
-if (DEFINED ENV{ProgramW6432})
-    file(TO_CMAKE_PATH "$ENV{ProgramW6432}" PROG_ROOT)
-else()
-    file(TO_CMAKE_PATH "$ENV{PROGRAMFILES}" PROG_ROOT)
-endif()
-if (DEFINED ENV{LLVMInstallDir})
-    file(TO_CMAKE_PATH "$ENV{LLVMInstallDir}/bin" LLVM_BIN_DIR)
-else()
-    file(TO_CMAKE_PATH "${PROG_ROOT}/LLVM/bin" LLVM_BIN_DIR)
-endif()
+file(TO_CMAKE_PATH "$ENV{ProgramW6432}/LLVM/bin" LLVM_BIN_DIR)
 
-find_program(CLANG_C_EXECUTABLE NAMES "clang.exe" PATHS ${LLVM_BIN_DIR} REQUIRED)
-find_program(CLANG_CXX_EXECUTABLE NAMES "clang++.exe" PATHS ${LLVM_BIN_DIR} REQUIRED)
-find_program(CLANG_RC_EXECUTABLE NAMES "llvm-rc.exe" PATHS ${LLVM_BIN_DIR} REQUIRED)
-find_program(CLANG_LLD_EXECUTABLE NAMES "lld-link.exe" PATHS ${LLVM_BIN_DIR} REQUIRED)
+# Set NO_DEFAULT_PATH to prevent the toolchain from picking up the copy of LLVM which ships with
+# Visual Studio, which may be outdated
+find_program(CLANG_C_EXECUTABLE NAMES "clang.exe" PATHS ${LLVM_BIN_DIR} NO_DEFAULT_PATH REQUIRED)
+find_program(CLANG_CXX_EXECUTABLE NAMES "clang++.exe" PATHS ${LLVM_BIN_DIR} NO_DEFAULT_PATH REQUIRED)
+find_program(CLANG_RC_EXECUTABLE NAMES "llvm-rc.exe" PATHS ${LLVM_BIN_DIR} NO_DEFAULT_PATH REQUIRED)
+find_program(CLANG_LLD_EXECUTABLE NAMES "lld-link.exe" PATHS ${LLVM_BIN_DIR} NO_DEFAULT_PATH REQUIRED)
 
 set(CMAKE_C_COMPILER ${CLANG_C_EXECUTABLE} CACHE STRING "" FORCE)
 set(CMAKE_CXX_COMPILER ${CLANG_CXX_EXECUTABLE} CACHE STRING "" FORCE)

--- a/triplets/x64-linux-llvm.cmake
+++ b/triplets/x64-linux-llvm.cmake
@@ -8,6 +8,9 @@ set(VCPKG_CMAKE_SYSTEM_NAME Linux)
 # release and debug builds in vcpkg.  This effectively breaks support for debug builds, for now.
 set(VCPKG_BUILD_TYPE release)
 
+# The toolchain file requires ProgramW6432 to determine the LLVM installation directory
+set(VCPKG_ENV_PASSTHROUGH_UNTRACKED "ProgramW6432") 
+
 # Configure toolchain
 set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/toolchains/x64-linux-llvm.toolchain.cmake")
 


### PR DESCRIPTION
On GitHub Actions, the toolchain currently picks up the copy of clang which ships with VS 2022. This is 17.x, which does not have full Objective-C support.

Instead:
- Pass through the `ProgramW6432` environment variable to the VCPKG environment
- Assume LLVM is installed in  `"$ENV{ProgramW6432}/LLVM/bin`