### PR TITLE
Make sure release and debug files are installed correctly

### DIFF
--- a/ports/vcpkg-gnustep/vcpkg_configure_gnustep.cmake
+++ b/ports/vcpkg-gnustep/vcpkg_configure_gnustep.cmake
@@ -78,25 +78,28 @@ function(vcpkg_configure_gnustep)
             list(APPEND all_buildtypes RELEASE)
         endif()
 
-        # Allow ./configure to find gnustep-config, which is in bin/
-        set(path_backup $ENV{PATH})
-        vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}${path_suffix_${current_buildtype}}/bin")
-
         foreach(current_buildtype IN LISTS all_buildtypes)
-            vcpkg_list(APPEND CONFIGURE_OPTIONS
-                                # ${prefix} has an extra backslash to prevent early expansion when calling `bash -c configure "..."`.
-                                "--prefix=${current_installed_dir_msys}${path_suffix_${current_buildtype}}"
-                                # Important: These should all be relative to prefix!
-                                "--bindir=\\\${prefix}/../tools/${PORT}${path_suffix_${current_buildtype}}/bin"
-                                "--sbindir=\\\${prefix}/../tools/${PORT}${path_suffix_${current_buildtype}}/sbin"
-                                "--libdir=\\\${prefix}/lib" # On some Linux distributions lib64 is the default
-                                "--datarootdir=\\\${prefix}/share/${PORT}"
-                                "--host=x86_64-pc-windows"
-                                "--target=x86_64-pc-windows"
-                                "CC=${GNUSTEP_C_COMPILER_NAME}"
-                                "CXX=${GNUSTEP_CXX_COMPILER_NAME}"
-                                "LDFLAGS=-fuse-ld=${GNUSTEP_LINKER_NAME}"
-                                ${arg_OPTIONS})
+            # Allow ./configure to find gnustep-config, which is in bin/
+            set(path_backup $ENV{PATH})
+            vcpkg_add_to_path("${CURRENT_INSTALLED_DIR}${path_suffix_${current_buildtype}}/bin")
+
+            # The same variable will be re-used in the foreach loop, so make sure to use set instead of
+            # append!
+            vcpkg_list(
+                SET CONFIGURE_OPTIONS
+                # ${prefix} has an extra backslash to prevent early expansion when calling `bash -c configure "..."`.
+                "--prefix=${current_installed_dir_msys}${path_suffix_${current_buildtype}}"
+                # Important: These should all be relative to prefix!
+                "--bindir=\\\${prefix}/../tools/${PORT}${path_suffix_${current_buildtype}}/bin"
+                "--sbindir=\\\${prefix}/../tools/${PORT}${path_suffix_${current_buildtype}}/sbin"
+                "--libdir=\\\${prefix}/lib" # On some Linux distributions lib64 is the default
+                "--datarootdir=\\\${prefix}/share/${PORT}"
+                "--host=x86_64-pc-windows"
+                "--target=x86_64-pc-windows"
+                "CC=${GNUSTEP_C_COMPILER_NAME}"
+                "CXX=${GNUSTEP_CXX_COMPILER_NAME}"
+                "LDFLAGS=-fuse-ld=${GNUSTEP_LINKER_NAME}"
+                ${arg_OPTIONS})
 
             list(JOIN CONFIGURE_OPTIONS " " CONFIGURE_OPTIONS)
 
@@ -110,9 +113,10 @@ function(vcpkg_configure_gnustep)
                 LOGNAME "config-${TARGET_TRIPLET}-${short_name_${current_buildtype}}"
                 SAVE_LOG_FILES config.log
             )
+
+            set(ENV{PATH} "${path_backup}")
         endforeach()
         
-        set(ENV{PATH} "${path_backup}")
     else()
         message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION} is not implemented for your platform")
     endif()


### PR DESCRIPTION
We were appending to `CONFIGURE_OPTIONS` inside the loop instead of resetting it at every iteration.  This caused the release configuration variables to leak into the debug build.